### PR TITLE
Car lists have been rearranged.

### DIFF
--- a/_data/cars/advanced.yml
+++ b/_data/cars/advanced.yml
@@ -1,11 +1,4 @@
 advanced:
-  kyoki:
-    name: Kyoki
-    slug: kyoki
-    speed: 56.8
-    acc: 2.73
-    weight: 1.4
-    multiplier: 0.7
   r6_turbo:
     name: R6 Turbo
     slug: r6_turbo
@@ -13,26 +6,12 @@ advanced:
     acc: 2.47
     weight: 0.8
     multiplier: 0.7
-  top_tier:
-    name: Top Tier
-    slug: top_tier
-    speed: 55.0
-    acc: 2.28
-    weight: 1.4
-    multiplier: 0.7
   alice:
     name: Alice
     slug: alice
     speed: 54.5
     acc: 2.32
     weight: 1.4
-    multiplier: 0.7
-  neifion:
-    name: Neifion
-    slug: neifion
-    speed: 56.5
-    acc: 2.39
-    weight: 1.7
     multiplier: 0.7
   ember:
     name: Ember
@@ -45,8 +24,22 @@ advanced:
     name: Hammerhead
     slug: hammerhead
     speed: 57.9
-    acc: 2
-    weight: 1.85
+    acc: 2.00
+    weight: 1.9
+    multiplier: 0.7
+  kyoki:
+    name: Kyoki
+    slug: kyoki
+    speed: 56.8
+    acc: 2.73
+    weight: 1.4
+    multiplier: 0.7
+  neifion:
+    name: Neifion
+    slug: neifion
+    speed: 56.5
+    acc: 2.39
+    weight: 1.7
     multiplier: 0.7
   p147_turbo:
     name: P147 Turbo
@@ -59,57 +52,22 @@ advanced:
     name: Pepperbox
     slug: pepperbox
     speed: 56.1
-    acc: 3.3
+    acc: 3.30
     weight: 1.2
     multiplier: 0.7
-  le_pastel:
-    name: Le Pastel
-    slug: le_pastel
-    speed: 56.6
-    acc: 2.18
-    weight: 2.0
-    multiplier: 0.8
-  drawall:
-    name: Drawall
-    slug: drawall
-    speed: 54.0
-    acc: 2.67
+  top_tier:
+    name: Top Tier
+    slug: top_tier
+    speed: 55.0
+    acc: 2.28
     weight: 1.4
-    multiplier: 0.8
-  nano_rascal:
-    name: Nano Rascal
-    slug: nano_rascal
-    speed: 50
-    acc: 2.25
-    weight: 0.99
-    multiplier: 0.8
-  rice_ball:
-    name: Rice Ball
-    slug: rice_ball
-    speed: 59
-    acc: 2
-    weight: 1.6
-    multiplier: 0.8
-  pegmound:
-    name: Pegmound
-    slug: pegmound
-    speed: 55
-    acc: 2.57
-    weight: 2.5
-    multiplier: 0.8
+    multiplier: 0.7
   bertha_ballistics:
     name: Bertha Ballistics
     slug: bertha_ballistics
     speed: 56.6
     acc: 2.24
     weight: 3.0
-    multiplier: 0.8
-  snakehead:
-    name: Snakehead
-    slug: snakehead
-    speed: 58
-    acc: 2.72
-    weight: 2.9
     multiplier: 0.8
   arctic_stomper:
     name: Arctic Stomper
@@ -118,13 +76,6 @@ advanced:
     acc: 2.38
     weight: 2.3
     multiplier: 0.8
-  springtrap:
-    name: Springtrap
-    slug: springtrap
-    speed: 54.9
-    acc: 2.81
-    weight: 1.2
-    multiplier: 0.8
   diamond:
     name: Diamond
     slug: diamond
@@ -132,6 +83,76 @@ advanced:
     acc: 2.23
     weight: 1.2
     multiplier: 0.8
+  drawall:
+    name: Drawall
+    slug: drawall
+    speed: 54.0
+    acc: 2.67
+    weight: 1.4
+    multiplier: 0.8
+  le_pastel:
+    name: Le Pastel
+    slug: le_pastel
+    speed: 56.6
+    acc: 2.18
+    weight: 2.0
+    multiplier: 0.8
+  nano_rascal:
+    name: Nano Rascal
+    slug: nano_rascal
+    speed: 50.0
+    acc: 2.25
+    weight: 1.0
+    multiplier: 0.8
+  pegmound:
+    name: Pegmound
+    slug: pegmound
+    speed: 55.0
+    acc: 2.57
+    weight: 2.5
+    multiplier: 0.8
+  rice_ball:
+    name: Rice Ball
+    slug: rice_ball
+    speed: 59.0
+    acc: 2.00
+    weight: 1.6
+    multiplier: 0.8
+  snakehead:
+    name: Snakehead
+    slug: snakehead
+    speed: 58.0
+    acc: 2.72
+    weight: 2.9
+    multiplier: 0.8
+  springtrap:
+    name: Springtrap
+    slug: springtrap
+    speed: 54.9
+    acc: 2.81
+    weight: 1.2
+    multiplier: 0.8
+  donnie_tc:
+    name: Donnie TC
+    slug: donnie_tc
+    speed: 58.0
+    acc: 2.60
+    weight: 1.7
+    multiplier: 0.9
+  drj-61:
+    name: DRJ-61
+    slug: drj-61
+    speed: 54.5
+    acc: 2.45
+    weight: 2.0
+    multiplier: 0.9
+  hyper_xl:
+    name: Hyper XL
+    slug: hyper_xl
+    speed: 57.5
+    acc: 2.50
+    weight: 1.8
+    multiplier: 0.9
   marauder:
     name: Marauder
     slug: marauder
@@ -139,33 +160,26 @@ advanced:
     acc: 1.96
     weight: 1.7
     multiplier: 0.9
-  donnie_tc:
-    name: Donnie TC
-    slug: donnie_tc
-    speed: 58
-    acc: 2.6
-    weight: 1.7
-    multiplier: 0.9
-  hyper_xl:
-    name: Hyper XL
-    slug: hyper_xl
-    speed: 57.5
-    acc: 2.5
-    weight: 1.75
-    multiplier: 0.9
-  drj-61:
-    name: DRJ-61
-    slug: drj-61
-    speed: 54.5
-    acc: 2.45
-    weight: 2
-    multiplier: 0.9
   panga_tc:
     name: Panga TC
     slug: panga_tc
     speed: 59.6
     acc: 2.13
     weight: 1.8
+    multiplier: 1.0
+  shocker:
+    name: Shocker
+    slug: shocker
+    speed: 57.0
+    acc: 2.13
+    weight: 1.8
+    multiplier: 1.0
+  flower_power:
+    name: Flower Power
+    slug: flower_power
+    speed: 57.6
+    acc: 2.76
+    weight: 1.6
     multiplier: 1.0
   llag_sat:
     name: Llag Sat
@@ -181,20 +195,6 @@ advanced:
     acc: 2.16
     weight: 1.7
     multiplier: 1.0
-  flower_power:
-    name: Flower Power
-    slug: flower_power
-    speed: 57.6
-    acc: 2.76
-    weight: 1.6
-    multiplier: 1.0
-  shocker:
-    name: Shocker
-    slug: shocker
-    speed: 57.0
-    acc: 2.13
-    weight: 1.8
-    multiplier: 1.0
   emperor:
     name: Emperor
     slug: emperor
@@ -209,19 +209,19 @@ advanced:
     acc: 2.18
     weight: 1.7
     multiplier: 1.1
-  groovster:
-    name: Groovster
-    slug: groovster
-    speed: 55.3
-    acc: 1.66
-    weight: 2.0
-    multiplier: 1.2
   bossvolt:
     name: BossVolt
     slug: bossvolt
     speed: 57.1
     acc: 2.16
     weight: 3.5
+    multiplier: 1.2
+  groovster:
+    name: Groovster
+    slug: groovster
+    speed: 55.3
+    acc: 1.66
+    weight: 2.0
     multiplier: 1.2
   evil_weasel:
     name: Evil Weasel
@@ -241,7 +241,7 @@ advanced:
     name: Akagi Attacker
     slug: akagi_attacker
     speed: 55.4
-    acc: 4.3
+    acc: 4.30
     weight: 1.5
     multiplier: 1.5
   splat:

--- a/_data/cars/advanced.yml
+++ b/_data/cars/advanced.yml
@@ -16,7 +16,7 @@ advanced:
   ember:
     name: Ember
     slug: ember
-    speed: 56
+    speed: 56.0
     acc: 2.37
     weight: 1.4
     multiplier: 0.7

--- a/_data/cars/amateur.yml
+++ b/_data/cars/amateur.yml
@@ -25,7 +25,7 @@ amateur:
     slug: clasica
     speed: 53.3
     acc: 2.83
-    weight: 1.85
+    weight: 1.9
     multiplier: 0.7
   gator:
     name: Gator
@@ -60,7 +60,7 @@ amateur:
     slug: wedge_chz
     speed: 52.6
     acc: 2.82
-    weight: 1
+    weight: 1.0
     multiplier: 0.7
   la_54:
     name: LA 54
@@ -95,14 +95,14 @@ amateur:
     slug: d-decker
     speed: 52.6
     acc: 2.46
-    weight: 1.85
+    weight: 1.9
     multiplier: 0.8
   devil:
     name: Devil
     slug: devil
     speed: 53.6
     acc: 2.13
-    weight: 2
+    weight: 2.0
     multiplier: 0.8
   evac:
     name: Evac

--- a/_data/cars/amateur.yml
+++ b/_data/cars/amateur.yml
@@ -13,12 +13,12 @@ amateur:
     acc: 3.17
     weight: 1.0
     multiplier: 0.7
-  starway:
-    name: Starway
-    slug: starway
-    speed: 52.0
-    acc: 2.80
-    weight: 1.5
+  bajrick:
+    name: Bajrick
+    slug: bajrick
+    speed: 54.4
+    acc: 1.85
+    weight: 1.4
     multiplier: 0.7
   clasica:
     name: Clasica
@@ -26,13 +26,6 @@ amateur:
     speed: 53.3
     acc: 2.83
     weight: 1.85
-    multiplier: 0.7
-  vixen:
-    name: Vixen
-    slug: vixen
-    speed: 51.6
-    acc: 2.47
-    weight: 1.5
     multiplier: 0.7
   gator:
     name: Gator
@@ -48,19 +41,26 @@ amateur:
     acc: 2.31
     weight: 1.5
     multiplier: 0.7
+  starway:
+    name: Starway
+    slug: starway
+    speed: 52.0
+    acc: 2.80
+    weight: 1.5
+    multiplier: 0.7
+  vixen:
+    name: Vixen
+    slug: vixen
+    speed: 51.6
+    acc: 2.47
+    weight: 1.5
+    multiplier: 0.7
   wedge_chz:
     name: Wedge CHZ
     slug: wedge_chz
     speed: 52.6
     acc: 2.82
     weight: 1
-    multiplier: 0.7
-  bajrick:
-    name: Bajrick
-    slug: bajrick
-    speed: 54.4
-    acc: 1.85
-    weight: 1.4
     multiplier: 0.7
   la_54:
     name: LA 54
@@ -69,11 +69,18 @@ amateur:
     acc: 2.52
     weight: 1.2
     multiplier: 0.8
+  matra_xl:
+    name: Matra XL
+    slug: matra_xl
+    speed: 55.6
+    acc: 2.12
+    weight: 1.4
+    multiplier: 0.8
   ashley:
     name: Ashley
     slug: ashley
     speed: 53.5
-    acc: 3.1
+    acc: 3.10
     weight: 1.4
     multiplier: 0.8
   bumblebee:
@@ -82,34 +89,6 @@ amateur:
     speed: 50.2
     acc: 2.28
     weight: 1.1
-    multiplier: 0.8
-  matra_xl:
-    name: Matra XL
-    slug: matra_xl
-    speed: 55.6
-    acc: 2.12
-    weight: 1.4
-    multiplier: 0.8
-  phantum:
-    name: Phantum
-    slug: phantum
-    speed: 54.9
-    acc: 1.88
-    weight: 1.6
-    multiplier: 0.8
-  locker:
-    name: Locker
-    slug: locker
-    speed: 52.0
-    acc: 2.98
-    weight: 1.4
-    multiplier: 0.8
-  stonemason:
-    name: Stonemason
-    slug: stonemason
-    speed: 55
-    acc: 2
-    weight: 2.3
     multiplier: 0.8
   d-decker:
     name: D-Decker
@@ -132,27 +111,27 @@ amateur:
     acc: 2.86
     weight: 1.5
     multiplier: 0.8
-  ignit-9:
-    name: Ignit-9
-    slug: ignit-9
-    speed: 51.7
-    acc: 2.30
-    weight: 1.5
-    multiplier: 0.9
-  muller_gt:
-    name: Muller GT
-    slug: muller_gt
-    speed: 52.2
-    acc: 2.41
+  locker:
+    name: Locker
+    slug: locker
+    speed: 52.0
+    acc: 2.98
     weight: 1.4
-    multiplier: 0.9
-  mongoose:
-    name: Mongoose
-    slug: mongoose
-    speed: 52.8
-    acc: 2
-    weight: 1.4
-    multiplier: 0.9
+    multiplier: 0.8
+  phantum:
+    name: Phantum
+    slug: phantum
+    speed: 54.9
+    acc: 1.88
+    weight: 1.6
+    multiplier: 0.8
+  stonemason:
+    name: Stonemason
+    slug: stonemason
+    speed: 55.0
+    acc: 2.00
+    weight: 2.3
+    multiplier: 0.8
   candy_pebbles:
     name: Candy Pebbles
     slug: candy_pebbles
@@ -171,8 +150,29 @@ amateur:
     name: Deep Blue
     slug: deep_blue
     speed: 56.5
-    acc: 2
+    acc: 2.00
     weight: 1.8
+    multiplier: 0.9
+  ignit-9:
+    name: Ignit-9
+    slug: ignit-9
+    speed: 51.7
+    acc: 2.30
+    weight: 1.5
+    multiplier: 0.9
+  mongoose:
+    name: Mongoose
+    slug: mongoose
+    speed: 52.8
+    acc: 2.00
+    weight: 1.4
+    multiplier: 0.9
+  muller_gt:
+    name: Muller GT
+    slug: muller_gt
+    speed: 52.2
+    acc: 2.41
+    weight: 1.4
     multiplier: 0.9
   strax:
     name: Strax
@@ -188,13 +188,6 @@ amateur:
     acc: 2.90
     weight: 2.3
     multiplier: 1.0
-  reddlum:
-    name: Reddlum
-    slug: reddlum
-    speed: 53.3
-    acc: 2.90
-    weight: 1.8
-    multiplier: 1.0
   kyarus:
     name: Kyarus
     slug: kyarus
@@ -207,7 +200,14 @@ amateur:
     slug: lmw
     speed: 55.7
     acc: 1.74
-    weight: 2
+    weight: 2.0
+    multiplier: 1.0
+  reddlum:
+    name: Reddlum
+    slug: reddlum
+    speed: 53.3
+    acc: 2.90
+    weight: 1.8
     multiplier: 1.0
   road_king:
     name: Road King
@@ -216,19 +216,19 @@ amateur:
     acc: 3.13
     weight: 2.8
     multiplier: 1.0
-  slim:
-    name: Slim
-    slug: slim
-    speed: 52.3
-    acc: 2.27
-    weight: 1.3
-    multiplier: 1.2
   elegant:
     name: Elegant
     slug: elegant
     speed: 56.9
     acc: 2.27
     weight: 1.9
+    multiplier: 1.2
+  slim:
+    name: Slim
+    slug: slim
+    speed: 52.3
+    acc: 2.27
+    weight: 1.3
     multiplier: 1.2
   rc_phink:
     name: RC Phink

--- a/_data/cars/pro.yml
+++ b/_data/cars/pro.yml
@@ -144,7 +144,7 @@ pro:
     slug: y_force
     speed: 67.2
     acc: 2.73
-    weight: 2
+    weight: 2.0
     multiplier: 0.9
   acclaim_f1:
     name: Acclaim F1
@@ -185,8 +185,8 @@ pro:
     name: Wildstar
     slug: wildstar
     speed: 66.1
-    acc: 3.6
-    weight: 1
+    acc: 3.60
+    weight: 1.0
     multiplier: 1.0
   patriot:
     name: Patriot

--- a/_data/cars/pro.yml
+++ b/_data/cars/pro.yml
@@ -1,11 +1,4 @@
 pro:
-  outlaw:
-    name: Outlaw
-    slug: outlaw
-    speed: 65.9
-    acc: 2.63
-    weight: 2.0
-    multiplier: 0.7
   snw_35:
     name: SNW 35
     slug: snw_35
@@ -25,20 +18,13 @@ pro:
     slug: cintach
     speed: 71.2
     acc: 2.52
-    weight: 2.26
+    weight: 2.3
     multiplier: 0.7
-  g3x:
-    name: G3X
-    slug: g3x
-    speed: 67
-    acc: 3.9
-    weight: 2
-    multiplier: 0.7
-  ryu:
-    name: Ryu
-    slug: ryu
-    speed: 63.9
-    acc: 3.34
+  drome_champ:
+    name: Drome Champ
+    slug: drome_champ
+    speed: 65.4
+    acc: 3.79
     weight: 1.5
     multiplier: 0.7
   exe_tc:
@@ -48,19 +34,47 @@ pro:
     acc: 3.61
     weight: 1.9
     multiplier: 0.7
-  drome_champ:
-    name: Drome Champ
-    slug: drome_champ
-    speed: 65.4
-    acc: 3.79
+  g3x:
+    name: G3X
+    slug: g3x
+    speed: 67.0
+    acc: 3.90
+    weight: 2.0
+    multiplier: 0.7
+  outlaw:
+    name: Outlaw
+    slug: outlaw
+    speed: 65.9
+    acc: 2.63
+    weight: 2.0
+    multiplier: 0.7
+  ryu:
+    name: Ryu
+    slug: ryu
+    speed: 63.9
+    acc: 3.34
     weight: 1.5
     multiplier: 0.7
+  toyeca:
+    name: Toyeca
+    slug: toyeca
+    speed: 64.6
+    acc: 3.21
+    weight: 2.0
+    multiplier: 0.8
   abomin8r:
     name: Abomin8r
     slug: abomin8r
     speed: 65.7
     acc: 3.13
     weight: 2.5
+    multiplier: 0.8
+  burning_steel:
+    name: Burning Steel
+    slug: burning_steel
+    speed: 68.1
+    acc: 3.50
+    weight: 1.5
     multiplier: 0.8
   chimera_tc:
     name: Chimera TC
@@ -69,20 +83,6 @@ pro:
     acc: 3.73
     weight: 1.6
     multiplier: 0.8
-  toyeca:
-    name: Toyeca
-    slug: toyeca
-    speed: 64.6
-    acc: 3.21
-    weight: 2.0
-    multiplier: 0.8
-  burning_steel:
-    name: Burning Steel
-    slug: burning_steel
-    speed: 68.1
-    acc: 3.5
-    weight: 1.45
-    multiplier: 0.8
   zs-9:
     name: ZS-9
     slug: zs-9
@@ -90,12 +90,40 @@ pro:
     acc: 2.54
     weight: 1.8
     multiplier: 0.8
+  humma:
+    name: Humma
+    slug: humma
+    speed: 63.9
+    acc: 3.46
+    weight: 2.0
+    multiplier: 0.9
   black_coffee:
     name: Black Coffee
     slug: black_coffee
     speed: 71.1
     acc: 2.91
     weight: 2.2
+    multiplier: 0.9
+  puma:
+    name: Puma
+    slug: puma
+    speed: 64.4
+    acc: 4.14
+    weight: 1.8
+    multiplier: 0.9
+  stadium_star:
+    name: Stadium Star
+    slug: stadium_star
+    speed: 63.8
+    acc: 2.88
+    weight: 2.0
+    multiplier: 0.9
+  steezy:
+    name: Steezy
+    slug: steezy
+    speed: 65.9
+    acc: 3.07
+    weight: 1.7
     multiplier: 0.9
   toro_gt84:
     name: Toro GT84
@@ -107,37 +135,9 @@ pro:
   visconti_r:
     name: Visconti R
     slug: visconti_r
-    speed: 63
+    speed: 63.0
     acc: 3.43
     weight: 1.8
-    multiplier: 0.9
-  puma:
-    name: Puma
-    slug: puma
-    speed: 64.4
-    acc: 4.14
-    weight: 1.8
-    multiplier: 0.9
-  steezy:
-    name: Steezy
-    slug: steezy
-    speed: 65.9
-    acc: 3.07
-    weight: 1.7
-    multiplier: 0.9
-  humma:
-    name: Humma
-    slug: humma
-    speed: 63.9
-    acc: 3.46
-    weight: 2.0
-    multiplier: 0.9
-  stadium_star:
-    name: Stadium Star
-    slug: stadium_star
-    speed: 63.8
-    acc: 2.88
-    weight: 2
     multiplier: 0.9
   y_force:
     name: Y Force
@@ -146,20 +146,6 @@ pro:
     acc: 2.73
     weight: 2
     multiplier: 0.9
-  sucker_punch:
-    name: Sucker Punch
-    slug: sucker_punch
-    speed: 66.4
-    acc: 3.18
-    weight: 1.25
-    multiplier: 1.0
-  sir_gleam:
-    name: Sir Gleam
-    slug: sir_gleam
-    speed: 67.3
-    acc: 4.44
-    weight: 1
-    multiplier: 1.0
   acclaim_f1:
     name: Acclaim F1
     slug: acclaim_f1
@@ -170,9 +156,30 @@ pro:
   core400:
     name: Core400
     slug: core400
-    speed: 67
+    speed: 67.0
     acc: 3.48
     weight: 1.6
+    multiplier: 1.0
+  karen:
+    name: Karen
+    slug: karen
+    speed: 65.0
+    acc: 2.87
+    weight: 1.8
+    multiplier: 1.0
+  sir_gleam:
+    name: Sir Gleam
+    slug: sir_gleam
+    speed: 67.3
+    acc: 4.44
+    weight: 1.0
+    multiplier: 1.0
+  sucker_punch:
+    name: Sucker Punch
+    slug: sucker_punch
+    speed: 66.4
+    acc: 3.18
+    weight: 1.3
     multiplier: 1.0
   wildstar:
     name: Wildstar
@@ -180,13 +187,6 @@ pro:
     speed: 66.1
     acc: 3.6
     weight: 1
-    multiplier: 1.0
-  karen:
-    name: Karen
-    slug: karen
-    speed: 65
-    acc: 2.87
-    weight: 1.8
     multiplier: 1.0
   patriot:
     name: Patriot

--- a/_data/cars/rookie.yml
+++ b/_data/cars/rookie.yml
@@ -1,4 +1,11 @@
 rookie:
+  rc_bandit:
+    name: Rc Bandit
+    slug: rc_bandit
+    speed: 51.5
+    acc: 2.09
+    weight: 1.2
+    multiplier: 0.7
   dr._grudge:
     name: Dr. Grudge
     slug: dr._grudge
@@ -13,13 +20,6 @@ rookie:
     acc: 3.20
     weight: 0.9
     multiplier: 0.7
-  kanberra_kruiser:
-    name: Kanberra Kruiser
-    slug: kanberra_kruiser
-    speed: 50.6
-    acc: 2.39
-    weight: 1.0
-    multiplier: 0.7
   el_gekko:
     name: El Gekko
     slug: el_gekko
@@ -27,18 +27,11 @@ rookie:
     acc: 2.02
     weight: 1.2
     multiplier: 0.7
-  rc_bandit:
-    name: Rc Bandit
-    slug: rc_bandit
-    speed: 51.5
-    acc: 2.09
-    weight: 1.2
-    multiplier: 0.7
   hurricane:
     name: Hurricane
     slug: hurricane
     speed: 48.7
-    acc: 9
+    acc: 9.0
     weight: 1.5
     multiplier: 0.7
   iso-77a:
@@ -48,6 +41,13 @@ rookie:
     acc: 2.75
     weight: 1.6
     multiplier: 0.7
+  kanberra_kruiser:
+    name: Kanberra Kruiser
+    slug: kanberra_kruiser
+    speed: 50.6
+    acc: 2.39
+    weight: 1.0
+    multiplier: 0.7
   road_star:
     name: Road Star
     slug: road_star
@@ -55,53 +55,18 @@ rookie:
     acc: 2.49
     weight: 0.8
     multiplier: 0.7
-  condor_grv:
-    name: Condor GRV
-    slug: condor_grv
-    speed: 51.3
-    acc: 2.73
-    weight: 1.5
-    multiplier: 0.8
-  trirraut:
-    name: Trirraut
-    slug: trirraut
-    speed: 52.6
-    acc: 2
-    weight: 1.3
-    multiplier: 0.8
-  poison_ivy:
-    name: Poison Ivy
-    slug: poison_ivy
-    speed: 51.8
-    acc: 2.32
-    weight: 1.2
-    multiplier: 0.8
-  lr_64:
-    name: LR 64
-    slug: lr_64
-    speed: 53.7
-    acc: 1.55
+  harvester:
+    name: Harvester
+    slug: harvester
+    speed: 47.7
+    acc: 2.33
     weight: 1.7
     multiplier: 0.8
-  bed_bug:
-    name: Bed Bug
-    slug: bed_bug
-    speed: 52.1
-    acc: 1.98
-    weight: 1.2
-    multiplier: 0.8
-  high-rod:
-    name: High-Rod
-    slug: high-rod
-    speed: 48.8
-    acc: 2.17
-    weight: 1.9
-    multiplier: 0.8
-  panorama:
-    name: Panorama
-    slug: panorama
-    speed: 50.4
-    acc: 2.31
+  abracadabra:
+    name: Abracadabra
+    slug: abracadabra
+    speed: 49.2
+    acc: 1.99
     weight: 1.4
     multiplier: 0.8
   albatross_gt:
@@ -111,19 +76,61 @@ rookie:
     acc: 2.36
     weight: 1.4
     multiplier: 0.8
-  abracadabra:
-    name: Abracadabra
-    slug: abracadabra
-    speed: 49.2
-    acc: 1.99
-    weight: 1.4
-    multiplier: 0.8
   b59:
     name: B59
     slug: b59
-    speed: 52
+    speed: 52.0
     acc: 1.62
     weight: 1.5
+    multiplier: 0.8
+  bed_bug:
+    name: Bed Bug
+    slug: bed_bug
+    speed: 52.1
+    acc: 1.98
+    weight: 1.2
+    multiplier: 0.8
+  condor_grv:
+    name: Condor GRV
+    slug: condor_grv
+    speed: 51.3
+    acc: 2.73
+    weight: 1.5
+    multiplier: 0.8
+  high-rod:
+    name: High-Rod
+    slug: high-rod
+    speed: 48.8
+    acc: 2.17
+    weight: 1.9
+    multiplier: 0.8
+  hot_spot:
+    name: Hot Spot
+    slug: hot_spot
+    speed: 51.2
+    acc: 2.36
+    weight: 1.0
+    multiplier: 0.8
+  lr_64:
+    name: LR 64
+    slug: lr_64
+    speed: 53.7
+    acc: 1.55
+    weight: 1.7
+    multiplier: 0.8
+  panorama:
+    name: Panorama
+    slug: panorama
+    speed: 50.4
+    acc: 2.31
+    weight: 1.4
+    multiplier: 0.8
+  poison_ivy:
+    name: Poison Ivy
+    slug: poison_ivy
+    speed: 51.8
+    acc: 2.32
+    weight: 1.2
     multiplier: 0.8
   pyramint:
     name: Pyramint
@@ -132,33 +139,26 @@ rookie:
     acc: 2.12
     weight: 1.4
     multiplier: 0.8
-  harvester:
-    name: Harvester
-    slug: harvester
-    speed: 47.7
-    acc: 2.33
-    weight: 1.7
-    multiplier: 0.8
-  hot_spot:
-    name: Hot Spot
-    slug: hot_spot
-    speed: 51.2
-    acc: 2.36
-    weight: 1
-    multiplier: 0.8
-  bigvolt:
-    name: BigVolt
-    slug: bigvolt
+  trirraut:
+    name: Trirraut
+    slug: trirraut
     speed: 52.6
-    acc: 2.36
-    weight: 2.3
-    multiplier: 0.9
+    acc: 2.00
+    weight: 1.3
+    multiplier: 0.8
   col._moss:
     name: Col. Moss
     slug: col._moss
     speed: 52.5
     acc: 2.16
     weight: 1.5
+    multiplier: 0.9
+  bigvolt:
+    name: BigVolt
+    slug: bigvolt
+    speed: 52.6
+    acc: 2.36
+    weight: 2.3
     multiplier: 0.9
   nesbitt:
     name: Nesbitt
@@ -184,8 +184,15 @@ rookie:
   gunior:
     name: Gunior
     slug: gunior
-    speed: 51
+    speed: 51.0
     acc: 2.67
+    weight: 1.3
+    multiplier: 1.0
+  manko_xs:
+    name: Manko XS
+    slug: manko_xs
+    speed: 52.1
+    acc: 2.13
     weight: 1.3
     multiplier: 1.0
   rouge:
@@ -195,26 +202,12 @@ rookie:
     acc: 2.57
     weight: 1.2
     multiplier: 1.0
-  manko_xs:
-    name: Manko XS
-    slug: manko_xs
-    speed: 52.1
-    acc: 2.13
-    weight: 1.25
-    multiplier: 1.0
-  super_wheat:
-    name: Super Wheat
-    slug: super_wheat
-    speed: 52.1
-    acc: 1.87
-    weight: 2.4
-    multiplier: 1.1
-  shiawase:
-    name: Shiawase
-    slug: shiawase
-    speed: 41.6
-    acc: 1
-    weight: 5
+  volken_turbo:
+    name: Volken Turbo
+    slug: volken_turbo
+    speed: 49.3
+    acc: 2.24
+    weight: 1.6
     multiplier: 1.1
   get_air:
     name: Get Air
@@ -223,12 +216,19 @@ rookie:
     acc: 3.31
     weight: 2.7
     multiplier: 1.1
-  volken_turbo:
-    name: Volken Turbo
-    slug: volken_turbo
-    speed: 49.3
-    acc: 2.24
-    weight: 1.6
+  shiawase:
+    name: Shiawase
+    slug: shiawase
+    speed: 41.6
+    acc: 1.00
+    weight: 5.0
+    multiplier: 1.1
+  super_wheat:
+    name: Super Wheat
+    slug: super_wheat
+    speed: 52.1
+    acc: 1.87
+    weight: 2.4
     multiplier: 1.1
   dust_mite:
     name: Dust Mite

--- a/_data/cars/rookie.yml
+++ b/_data/cars/rookie.yml
@@ -31,7 +31,7 @@ rookie:
     name: Hurricane
     slug: hurricane
     speed: 48.7
-    acc: 9.0
+    acc: 9.00
     weight: 1.5
     multiplier: 0.7
   iso-77a:

--- a/_data/cars/semi-pro.yml
+++ b/_data/cars/semi-pro.yml
@@ -1,52 +1,10 @@
 semi-pro:
-  dual_signal:
-    name: Dual Signal
-    slug: dual_signal
-    speed: 59.2
-    acc: 2.58
-    weight: 1.7
-    multiplier: 0.7
-  dragoon:
-    name: Dragoon
-    slug: dragoon
-    speed: 60.9
-    acc: 2.27
-    weight: 2.2
-    multiplier: 0.7
-  victoria:
-    name: Victoria
-    slug: victoria
-    speed: 58.1
-    acc: 2.93
-    weight: 1.7
-    multiplier: 0.7
-  sokudo:
-    name: Sokudo
-    slug: sokudo
-    speed: 56.3
-    acc: 5.2
-    weight: 1.2
-    multiplier: 0.7
-  yuurei_v8:
-    name: Yuurei V8
-    slug: yuurei_v8
-    speed: 58
-    acc: 3
-    weight: 1.7
-    multiplier: 0.7
   adeon:
     name: Adeon
     slug: adeon
     speed: 59.0
     acc: 2.97
     weight: 1.2
-    multiplier: 0.7
-  ducktail:
-    name: Ducktail
-    slug: ducktail
-    speed: 60
-    acc: 2.46
-    weight: 2
     multiplier: 0.7
   acclaim_gt:
     name: Acclaim GT
@@ -55,19 +13,54 @@ semi-pro:
     acc: 2.76
     weight: 1.3
     multiplier: 0.7
+  dragoon:
+    name: Dragoon
+    slug: dragoon
+    speed: 60.9
+    acc: 2.27
+    weight: 2.2
+    multiplier: 0.7
+  dual_signal:
+    name: Dual Signal
+    slug: dual_signal
+    speed: 59.2
+    acc: 2.58
+    weight: 1.7
+    multiplier: 0.7
+  ducktail:
+    name: Ducktail
+    slug: ducktail
+    speed: 60.0
+    acc: 2.46
+    weight: 2.0
+    multiplier: 0.7
+  sokudo:
+    name: Sokudo
+    slug: sokudo
+    speed: 56.3
+    acc: 5.20
+    weight: 1.2
+    multiplier: 0.7
+  victoria:
+    name: Victoria
+    slug: victoria
+    speed: 58.1
+    acc: 2.93
+    weight: 1.7
+    multiplier: 0.7
+  yuurei_v8:
+    name: Yuurei V8
+    slug: yuurei_v8
+    speed: 58.0
+    acc: 3.0
+    weight: 1.7
+    multiplier: 0.7
   zipper:
     name: Zipper
     slug: zipper
     speed: 60.6
     acc: 2.82
     weight: 1.4
-    multiplier: 0.8
-  teacee:
-    name: Teacee
-    slug: teacee
-    speed: 60.0
-    acc: 2.90
-    weight: 2.0
     multiplier: 0.8
   jg-7:
     name: JG-7
@@ -76,13 +69,6 @@ semi-pro:
     acc: 2.72
     weight: 1.2
     multiplier: 0.8
-  mambra:
-    name: Mambra
-    slug: mambra
-    speed: 58.5
-    acc: 4.37
-    weight: 1.6
-    multiplier: 0.8
   ancile:
     name: Ancile
     slug: ancile
@@ -90,26 +76,26 @@ semi-pro:
     acc: 2.29
     weight: 2.5
     multiplier: 0.8
-  sneaky:
-    name: Sneaky
-    slug: sneaky
-    speed: 56.4
-    acc: 3.3
-    weight: 0.84
-    multiplier: 0.8
-  serranillo:
-    name: Serranillo
-    slug: serranillo
-    speed: 56.6
-    acc: 2.77
-    weight: 1.6
-    multiplier: 0.8
-  touga:
-    name: Touga
-    slug: touga
-    speed: 65.6
-    acc: 3.08
+  bushido_rs:
+    name: Bushido RS
+    slug: bushido_rs
+    speed: 57.7
+    acc: 3.31
     weight: 2.0
+    multiplier: 0.8
+  jungle_beast:
+    name: Jungle Beast
+    slug: jungle_beast
+    speed: 56.5
+    acc: 3.65
+    weight: 1.9
+    multiplier: 0.8
+  mambra:
+    name: Mambra
+    slug: mambra
+    speed: 58.5
+    acc: 4.37
+    weight: 1.6
     multiplier: 0.8
   rc-erra:
     name: RC-Erra
@@ -125,33 +111,40 @@ semi-pro:
     acc: 2.41
     weight: 1.6
     multiplier: 0.8
-  bushido_rs:
-    name: Bushido RS
-    slug: bushido_rs
-    speed: 57.7
-    acc: 3.31
-    weight: 2
+  serranillo:
+    name: Serranillo
+    slug: serranillo
+    speed: 56.6
+    acc: 2.77
+    weight: 1.6
     multiplier: 0.8
-  jungle_beast:
-    name: Jungle Beast
-    slug: jungle_beast
-    speed: 56.5
-    acc: 3.65
-    weight: 1.9
+  sneaky:
+    name: Sneaky
+    slug: sneaky
+    speed: 56.4
+    acc: 3.30
+    weight: 0.8
     multiplier: 0.8
-  speed_balancer:
-    name: Speed Balancer
-    slug: speed_balancer
-    speed: 62.0
-    acc: 3.22
-    weight: 1.8
-    multiplier: 0.9
-  runner_2000:
-    name: Runner 2000
-    slug: runner_2000
-    speed: 59.7
-    acc: 3.18
-    weight: 1.3
+  teacee:
+    name: Teacee
+    slug: teacee
+    speed: 60.0
+    acc: 2.90
+    weight: 2.0
+    multiplier: 0.8
+  touga:
+    name: Touga
+    slug: touga
+    speed: 65.6
+    acc: 3.08
+    weight: 2.0
+    multiplier: 0.8
+  kappa_ii:
+    name: Kappa II
+    slug: kappa_ii
+    speed: 62.9
+    acc: 3.83
+    weight: 1.4
     multiplier: 0.9
   m4_dirtmaster:
     name: M4 Dirtmaster
@@ -160,19 +153,26 @@ semi-pro:
     acc: 2.45
     weight: 1.9
     multiplier: 0.9
-  kappa_ii:
-    name: Kappa II
-    slug: kappa_ii
-    speed: 62.9
-    acc: 3.83
-    weight: 1.4
+  runner_2000:
+    name: Runner 2000
+    slug: runner_2000
+    speed: 59.7
+    acc: 3.18
+    weight: 1.3
     multiplier: 0.9
   sasquatch:
     name: Sasquatch
     slug: sasquatch
     speed: 61.2
     acc: 2.48
-    weight: 3
+    weight: 3.0
+    multiplier: 0.9
+  speed_balancer:
+    name: Speed Balancer
+    slug: speed_balancer
+    speed: 62.0
+    acc: 3.22
+    weight: 1.8
     multiplier: 0.9
   rg1:
     name: RG1
@@ -186,13 +186,13 @@ semi-pro:
     slug: nrg
     speed: 57.3
     acc: 5.55
-    weight: 1
+    weight: 1.0
     multiplier: 1.0
   5tp:
     name: 5TP
     slug: 5tp
-    speed: 62
-    acc: 3
+    speed: 62.0
+    acc: 3.00
     weight: 2.5
     multiplier: 1.1
   ballista:
@@ -216,13 +216,6 @@ semi-pro:
     acc: 1.94
     weight: 3.7
     multiplier: 1.3
-  pole_poz:
-    name: Pole Poz
-    slug: pole_poz
-    speed: 60.3
-    acc: 2.53
-    weight: 1.7
-    multiplier: 2.3
   pest_control:
     name: Pest Control
     slug: pest_control
@@ -230,17 +223,24 @@ semi-pro:
     acc: 1.66
     weight: 2.0
     multiplier: 2.3
-  rv_loco:
-    name: RV Loco
-    slug: rv_loco
-    speed: 63.3
-    acc: 1.98
-    weight: 2.3
-    multiplier: 4.0
+  pole_poz:
+    name: Pole Poz
+    slug: pole_poz
+    speed: 60.3
+    acc: 2.53
+    weight: 1.7
+    multiplier: 2.3
   rotor:
     name: Rotor
     slug: rotor
     speed: 64.9
     acc: 2.02
     weight: 3.0
+    multiplier: 4.0
+  rv_loco:
+    name: RV Loco
+    slug: rv_loco
+    speed: 63.3
+    acc: 1.98
+    weight: 2.3
     multiplier: 4.0

--- a/_data/cars/super-pro.yml
+++ b/_data/cars/super-pro.yml
@@ -1,10 +1,10 @@
 super-pro:
-  endo:
-    name: Endo
-    slug: endo
-    speed: 71.1
-    acc: 4.74
-    weight: 2.7
+  alterego:
+    name: Alterego
+    slug: alterego
+    speed: 69.9
+    acc: 3.56
+    weight: 2.0
     multiplier: 0.7
   armand:
     name: Armand
@@ -13,47 +13,40 @@ super-pro:
     acc: 4.17
     weight: 1.5
     multiplier: 0.7
+  endo:
+    name: Endo
+    slug: endo
+    speed: 71.1
+    acc: 4.74
+    weight: 2.7
+    multiplier: 0.7
   pearl:
     name: Pearl
     slug: pearl
     speed: 73.8
     acc: 2.73
-    weight: 2
-    multiplier: 0.7
-  sapphire:
-    name: Sapphire
-    slug: sapphire
-    speed: 69.8
-    acc: 4.2
-    weight: 1.45
-    multiplier: 0.7
-  track_reaper:
-    name: Track Reaper
-    slug: track_reaper
-    speed: 74.8
-    acc: 3.1
-    weight: 2
-    multiplier: 0.7
-  alterego:
-    name: Alterego
-    slug: alterego
-    speed: 69.9
-    acc: 3.56
-    weight: 2
-    multiplier: 0.7
-  stinger:
-    name: Stinger
-    slug: stinger
-    speed: 70.2
-    acc: 3.08
-    weight: 2
+    weight: 2.0
     multiplier: 0.7
   reiser:
     name: Reiser
     slug: reiser
     speed: 70.5
     acc: 3.34
-    weight: 2
+    weight: 2.0
+    multiplier: 0.7
+  sapphire:
+    name: Sapphire
+    slug: sapphire
+    speed: 69.8
+    acc: 4.20
+    weight: 1.5
+    multiplier: 0.7
+  stinger:
+    name: Stinger
+    slug: stinger
+    speed: 70.2
+    acc: 3.08
+    weight: 2.0
     multiplier: 0.7
   super_phantum:
     name: Super Phantum
@@ -62,11 +55,18 @@ super-pro:
     acc: 3.39
     weight: 1.4
     multiplier: 0.7
-  xm250:
-    name: XM250
-    slug: xm250
-    speed: 70.2
-    acc: 3.13
+  track_reaper:
+    name: Track Reaper
+    slug: track_reaper
+    speed: 74.8
+    acc: 3.10
+    weight: 2.0
+    multiplier: 0.7
+  cambold_r:
+    name: Cambold R
+    slug: cambold_r
+    speed: 70.9
+    acc: 3.70
     weight: 1.4
     multiplier: 0.8
   commandine:
@@ -76,26 +76,12 @@ super-pro:
     acc: 3.44
     weight: 2.0
     multiplier: 0.8
-  nova:
-    name: Nova
-    slug: nova
-    speed: 73.7
-    acc: 4.21
-    weight: 2
-    multiplier: 0.8
-  tesseract:
-    name: Tesseract
-    slug: tesseract
-    speed: 71.3
-    acc: 4
-    weight: 2
-    multiplier: 0.8
-  prototype_fx77:
-    name: Prototype FX77
-    slug: prototype_fx77
-    speed: 65.1
-    acc: 2.99
-    weight: 1.2
+  daemmon:
+    name: Daemmon
+    slug: daemmon
+    speed: 74.4
+    acc: 3.87
+    weight: 1.9
     multiplier: 0.8
   la_rossa:
     name: La Rossa
@@ -104,12 +90,26 @@ super-pro:
     acc: 4.16
     weight: 2.0
     multiplier: 0.8
+  nova:
+    name: Nova
+    slug: nova
+    speed: 73.7
+    acc: 4.21
+    weight: 2.0
+    multiplier: 0.8
+  prototype_fx77:
+    name: Prototype FX77
+    slug: prototype_fx77
+    speed: 65.1
+    acc: 2.99
+    weight: 1.2
+    multiplier: 0.8
   sideswipe:
     name: Sideswipe
     slug: sideswipe
     speed: 70.4
     acc: 3.86
-    weight: 2
+    weight: 2.0
     multiplier: 0.8
   starmac:
     name: Starmac
@@ -118,48 +118,20 @@ super-pro:
     acc: 3.54
     weight: 1.8
     multiplier: 0.8
-  daemmon:
-    name: Daemmon
-    slug: daemmon
-    speed: 74.4
-    acc: 3.87
-    weight: 1.85
+  tesseract:
+    name: Tesseract
+    slug: tesseract
+    speed: 71.3
+    acc: 4.00
+    weight: 2.0
     multiplier: 0.8
-  cambold_r:
-    name: Cambold R
-    slug: cambold_r
-    speed: 70.9
-    acc: 3.70
+  xm250:
+    name: XM250
+    slug: xm250
+    speed: 70.2
+    acc: 3.13
     weight: 1.4
     multiplier: 0.8
-  gungnir:
-    name: Gungnir
-    slug: gungnir
-    speed: 67.7
-    acc: 3.45
-    weight: 3.3
-    multiplier: 0.9
-  devyaty:
-    name: Devyaty
-    slug: devyaty
-    speed: 74.2
-    acc: 2.69
-    weight: 2
-    multiplier: 0.9
-  voltrex:
-    name: Voltrex
-    slug: voltrex
-    speed: 72.7
-    acc: 3.88
-    weight: 1.3
-    multiplier: 0.9
-  king_moloko:
-    name: King Moloko
-    slug: king_moloko
-    speed: 77
-    acc: 3
-    weight: 2.7
-    multiplier: 0.9
   calcure:
     name: Calcure
     slug: calcure
@@ -167,12 +139,33 @@ super-pro:
     acc: 2.87
     weight: 2.0
     multiplier: 0.9
+  devyaty:
+    name: Devyaty
+    slug: devyaty
+    speed: 74.2
+    acc: 2.69
+    weight: 2.0
+    multiplier: 0.9
+  gungnir:
+    name: Gungnir
+    slug: gungnir
+    speed: 67.7
+    acc: 3.45
+    weight: 3.3
+    multiplier: 0.9
+  king_moloko:
+    name: King Moloko
+    slug: king_moloko
+    speed: 77.0
+    acc: 3.00
+    weight: 2.7
+    multiplier: 0.9
   madax_gt:
     name: Madax GT
     slug: madax_gt
     speed: 71.3
     acc: 2.76
-    weight: 2.15
+    weight: 2.2
     multiplier: 0.9
   megalodon_xl:
     name: Megalodon XL
@@ -184,31 +177,17 @@ super-pro:
   nakajima:
     name: Nakajima
     slug: nakajima
-    speed: 76
-    acc: 3.2
-    weight: 1.25
+    speed: 76.0
+    acc: 3.20
+    weight: 1.3
     multiplier: 0.9
-  king_kaiju:
-    name: King Kaiju
-    slug: king_kaiju
-    speed: 72.6
-    acc: 4.41
-    weight: 1.8
-    multiplier: 1.0
-  volken_champion:
-    name: Volken Champion
-    slug: volken_champion
-    speed: 71.7
-    acc: 3.9
-    weight: 1.5
-    multiplier: 1.0
-  saeger:
-    name: Saeger
-    slug: saeger
-    speed: 69.6
-    acc: 5.81
-    weight: 2
-    multiplier: 1.0
+  voltrex:
+    name: Voltrex
+    slug: voltrex
+    speed: 72.7
+    acc: 3.88
+    weight: 1.3
+    multiplier: 0.9
   flir:
     name: FLIR
     slug: flir
@@ -222,6 +201,27 @@ super-pro:
     speed: 78.2
     acc: 3.38
     weight: 2.5
+    multiplier: 1.0
+  king_kaiju:
+    name: King Kaiju
+    slug: king_kaiju
+    speed: 72.6
+    acc: 4.41
+    weight: 1.8
+    multiplier: 1.0
+  saeger:
+    name: Saeger
+    slug: saeger
+    speed: 69.6
+    acc: 5.81
+    weight: 2.0
+    multiplier: 1.0
+  volken_champion:
+    name: Volken Champion
+    slug: volken_champion
+    speed: 71.7
+    acc: 3.90
+    weight: 1.5
     multiplier: 1.0
   rinne:
     name: Rinne
@@ -248,6 +248,6 @@ super-pro:
     name: Screamer
     slug: screamer
     speed: 77.3
-    acc: 3
+    acc: 3.00
     weight: 1.4
     multiplier: 1.7


### PR DESCRIPTION
**Note: None of the car multipliers were modified.**

The reason of this PR is because I noticed that between each group of cars with a same multiplier they were kinda randomly sorted. So I went to the corresponding files and rearranged the cars following the next set of instructions:

1. By multiplier upwardly (that doesn't changed compared to before).
2. Stock and DC cars by how they're sorted in the game.
3. Custom cars, alphabetically sorted.

That's it about how I sorted the cars. Now, about the amount of digits for the speed, acceleration and weight, I've set 3 [significant digits](https://en.wikipedia.org/wiki/Significant_figures) for the speed and acceleration and 2 for the weight; so for example if there were values of acc like `2` and `1.9`, those were edited as `2.00` and `1.90` respectively.